### PR TITLE
Add web UI, idle delay, smarter recognition, and install improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,16 @@ Options:
 
 ---
 
+## Documentation hygiene
+
+Whenever a feature is added, a flag is changed, or a workflow changes:
+
+- **README.md** — keep "Installation", "First-time setup", "Troubleshooting", and "Configuration reference" in sync. A user following the README from scratch should succeed without consulting the code.
+- **CLAUDE.md** — keep Architecture, Deployment, and What NOT to do current. If a section describes something that no longer exists, update or remove it.
+- **Install scripts** — `--help` output must match the flags actually accepted.
+
+If you make a change and notice that any of these are stale, update them in the same commit.
+
 ## What NOT to do
 
 - Do not block the ALSA device with multiple `arecord` calls — consume the PCM socket from `oceano-source-detector` instead; PipeWire monitor taps are the long-term replacement

--- a/README.md
+++ b/README.md
@@ -6,21 +6,15 @@ Provides a unified playback state file (`/tmp/oceano-state.json`) and a real-tim
 VU meter socket (`/tmp/oceano-vu.sock`) that the UI reads, regardless of the
 active source (AirPlay, physical media, or silence).
 
-## Services
-
-| Service | Install script | Role |
-|---|---|---|
-| `shairport-sync.service` | `install.sh` | AirPlay receiver |
-| `oceano-airplay-bridge.service` | `install.sh` | Routes loopback audio to DAC |
-| `oceano-bridge-watchdog.service` | `install.sh` | Reconnects bridge when DAC wakes from standby |
-| `oceano-source-detector.service` | `install-source-detector.sh` | Captures REC-OUT via USB capture card; detects physical media presence; publishes VU frames |
-| `oceano-state-manager.service` | `install-source-manager.sh` | Merges all sources into `/tmp/oceano-state.json` |
-
 ---
 
 ## Installation (on the Pi)
 
 Raspberry Pi OS 64-bit (Bookworm) recommended.
+
+**Before running the installer**, make sure the amplifier is powered on and the
+input selector is set to **USB** — the DAC only appears in the ALSA device list
+when it is active.
 
 ```bash
 curl -fsSL -o install.sh https://raw.githubusercontent.com/alemser/oceano-player/main/install.sh
@@ -28,7 +22,8 @@ chmod +x install.sh
 sudo ./install.sh
 ```
 
-This single command installs and starts all services:
+This single command installs all services and dependencies (including Go,
+`shairport-sync`, and `alsa-utils`):
 
 | Service | Role |
 |---|---|
@@ -39,15 +34,77 @@ This single command installs and starts all services:
 | `oceano-state-manager` | Merges all sources into `/tmp/oceano-state.json` |
 | `oceano-web` | Configuration UI at `http://<pi-ip>:8080` |
 
-After install, open `http://<pi-ip>:8080` in your browser to:
-- Set ACRCloud credentials for track recognition
-- Configure audio input/output devices
-- Adjust silence threshold and debounce settings
+---
 
-Verify:
+## First-time setup after install
+
+After installation, open `http://<pi-ip>:8080` in your browser and configure:
+
+### 1. Audio capture level (required for track recognition)
+
+The USB capture card volume must be set so that RMS stays between **0.05–0.25**
+during playback. The calibrated value for the Magnat MR 780 + DIGITNOW card is:
+
 ```bash
-sudo systemctl status shairport-sync.service oceano-source-detector.service oceano-state-manager.service oceano-web.service
-journalctl -u oceano-web.service -f
+amixer -c 3 sset 'Mic' 3   # reduces level to ~19% → RMS ≈ 0.19
+alsactl store               # persist across reboots
+```
+
+Run this on the Pi before configuring recognition. Check the level with:
+```bash
+journalctl -u oceano-source-detector.service -f
+# look for: heartbeat: source=Physical rms=X
+```
+
+### 2. ACRCloud credentials (required for track recognition)
+
+Track identification (artist, title, album) for physical media (vinyl, CD) is
+powered by [ACRCloud](https://www.acrcloud.com). Without credentials, `track`
+will always be `null` for physical sources.
+
+In the web UI at `http://<pi-ip>:8080`, go to **Track Recognition** and fill in:
+- **ACRCloud Host** — e.g. `identify-eu-west-1.acrcloud.com`
+- **Access Key**
+- **Secret Key**
+
+Click **Save & Restart Services**. Confirm recognition is active:
+```bash
+journalctl -u oceano-state-manager.service -f | grep recognizer
+# should show: recognizer [ACRCloud]: capturing ...
+```
+
+### 3. Audio input device (if auto-detection fails)
+
+The capture card is auto-detected by name (`USB Microphone`). If it is not found,
+set it explicitly in the web UI under **Audio Input → Device** (e.g. `plughw:3,0`).
+
+To list available capture devices:
+```bash
+arecord -l
+```
+
+---
+
+## Update
+
+Re-run the main installer to update all services at once:
+
+```bash
+sudo ./install.sh
+```
+
+To deploy a specific branch:
+
+```bash
+sudo ./install.sh --branch my-branch
+```
+
+Individual services can still be updated independently:
+
+```bash
+sudo ./install-source-detector.sh --branch my-branch
+sudo ./install-source-manager.sh --branch my-branch
+sudo ./install-oceano-web.sh --branch my-branch
 ```
 
 ---
@@ -77,8 +134,7 @@ Written atomically whenever state changes. The UI polls or watches this file.
 
 `source` values: `AirPlay` | `Physical` | `None`
 
-`track` is `null` when `source` is `Physical` (metadata identification is a future
-feature) or `None`.
+`track` is `null` when source is `Physical` and no recognition result is available yet, or when source is `None`.
 
 **UI progress interpolation** — to avoid polling for seek position:
 ```
@@ -107,33 +163,79 @@ Frame rate: ~22 fps (2048-sample buffer at 44.1 kHz ≈ 46 ms per frame).
 
 ---
 
-## Update
+## Troubleshooting
 
-Re-run the main installer to update all services at once:
+### AirPlay not appearing on iPhone / devices
 
-```bash
-sudo ./install.sh
-```
+1. **Amplifier input not set to USB** — shairport-sync needs the DAC to be present at startup. Set the input to USB and re-run `sudo ./install.sh`.
 
-To deploy a specific branch:
+2. **shairport-sync not running**:
+   ```bash
+   sudo systemctl status shairport-sync.service
+   journalctl -u shairport-sync.service -n 30 --no-pager
+   ```
 
-```bash
-sudo ./install.sh --branch my-branch
-```
+3. **Loopback module not loaded**:
+   ```bash
+   lsmod | grep snd_aloop
+   # if empty: sudo modprobe snd-aloop
+   ```
 
-Individual services can still be updated independently when needed:
+---
 
-```bash
-sudo ./install-source-detector.sh --branch my-branch
-sudo ./install-source-manager.sh --branch my-branch
-sudo ./install-oceano-web.sh --branch my-branch
-```
+### Track recognition not working (`track: null` for physical source)
+
+1. **ACRCloud credentials not configured** — the most common cause after a fresh install. Open `http://<pi-ip>:8080` → **Track Recognition** → fill in credentials → **Save & Restart Services**.
+
+2. **RMS too high (> 0.40)** — clipping corrupts the audio fingerprint. Reduce capture volume:
+   ```bash
+   amixer -c 3 sset 'Mic' 3
+   alsactl store
+   ```
+   The working value on the Magnat MR 780 + DIGITNOW card is **level 3 → RMS ≈ 0.19**.
+
+3. **Source detector showing `None`** — the capture card may not be detected:
+   ```bash
+   journalctl -u oceano-source-detector.service -f
+   # look for: heartbeat: source=Physical rms=X
+   # if source=None while music is playing, check --device-match in the web UI
+   ```
+
+4. **Network unreachable (IPv6)** — ACRCloud client forces IPv4. Confirm connectivity:
+   ```bash
+   curl -4 https://identify-eu-west-1.acrcloud.com
+   ```
+
+---
+
+### Source oscillating rapidly between Physical and None
+
+The silence threshold is too close to the noise floor at the current capture volume. In the web UI under **Audio Input**, raise **Silence Threshold** to `0.025`.
+
+---
+
+### Track info stays on screen after record is changed
+
+The last recognized track is shown for 60 seconds after audio stops (configurable via `--idle-delay`). If the phono stage has residual hum keeping RMS above the threshold, the source stays `Physical` and the old track persists until the next recognition cycle.
+
+Options:
+- Raise **Silence Threshold** slightly in the web UI so phono hum is treated as silence
+- The recognizer retries at every track boundary (silence → audio transition)
+
+---
+
+### Album art shows wrong album
+
+Expected when playing a compilation or "Best Of". ACRCloud identifies by audio fingerprint and returns the best-known release for that recording — which may be credited to "Various Artists" in music databases, causing the artwork lookup to fail.
 
 ---
 
 ## Configuration reference
 
-### `install.sh`
+All service parameters are managed through the web UI at `http://<pi-ip>:8080`.
+The underlying config is stored at `/etc/oceano/config.json`.
+
+### `install.sh` options
 
 | Option | Default | Description |
 |---|---|---|
@@ -142,27 +244,9 @@ sudo ./install-oceano-web.sh --branch my-branch
 | `--alsa-device` | *(auto-detected)* | Explicit ALSA device string |
 | `--preplay-wait-seconds` | `8` | Seconds to wait for DAC wake-up before playback |
 | `--output-strategy` | `loopback` | `loopback` or `direct` |
+| `--branch` | `main` | Git branch to install |
 
-Persistent config at `/opt/oceano-player/config.env` — edit and re-run to apply.
-
-### `install-source-detector.sh`
-
-| Option | Default | Description |
-|---|---|---|
-| `--device-match` | `USB Microphone` | Substring to match in `/proc/asound/cards` (auto-detects card number) |
-| `--device` | *(none)* | Explicit ALSA fallback device if match fails |
-| `--silence-threshold` | `0.008` | RMS below this = no physical source |
-| `--debounce` | `10` | Majority vote window size |
-| `--vu-socket` | `/tmp/oceano-vu.sock` | Unix socket for VU meter frames |
-
-### `install-source-manager.sh`
-
-| Option | Default | Description |
-|---|---|---|
-| `--metadata-pipe` | `/tmp/shairport-sync-metadata` | shairport-sync metadata FIFO |
-| `--source-file` | `/tmp/oceano-source.json` | Source detector output |
-| `--output` | `/tmp/oceano-state.json` | Unified state output |
-| `--artwork-dir` | `/tmp` | Directory for artwork cache files |
+Persistent config at `/opt/oceano-player/config.env`.
 
 ---
 
@@ -179,6 +263,8 @@ curl -fsSL -o install.sh https://raw.githubusercontent.com/alemser/oceano-player
 chmod +x install.sh
 sudo ./install.sh
 ```
+
+After reinstall, remember to re-configure ACRCloud credentials in the web UI and re-run `amixer` to set the capture level.
 
 ---
 
@@ -210,4 +296,3 @@ git config core.hooksPath .githooks
 - HTTP + SSE server in state manager (real-time push to UI, replaces file polling)
 - PipeWire migration — replace `arecord` single-reader model with monitor taps
 - Local recognition cache — use Chromaprint (`fpcalc`) fingerprint as cache key for ACRCloud results, persisted to disk; avoids redundant API calls when replaying the same vinyl pressing
-- Configuration UI for device settings (ALSA device, thresholds, display mode)

--- a/cmd/oceano-state-manager/main.go
+++ b/cmd/oceano-state-manager/main.go
@@ -85,12 +85,15 @@ type Config struct {
 	PCMSocket                 string
 	RecognizerCaptureDuration time.Duration
 	// RecognizerMaxInterval is the fallback re-recognition interval when no track
-	// boundary is detected (e.g. long continuous playback without a silence gap).
+	// boundary is detected and no result is held yet.
 	RecognizerMaxInterval time.Duration
 	// VUSocket is the Unix socket path for VU frames from oceano-source-detector.
 	// The state manager subscribes to detect silence→audio transitions (track boundaries)
 	// and uses them to trigger recognition at the right moment.
 	VUSocket string
+	// IdleDelay is how long to keep showing the last physical track after audio stops
+	// before switching to the idle screen. Defaults to 60 seconds.
+	IdleDelay time.Duration
 }
 
 func defaultConfig() Config {
@@ -103,6 +106,7 @@ func defaultConfig() Config {
 		VUSocket:                  "/tmp/oceano-vu.sock",
 		RecognizerCaptureDuration: 10 * time.Second,
 		RecognizerMaxInterval:     5 * time.Minute,
+		IdleDelay:                 60 * time.Second,
 	}
 }
 
@@ -125,6 +129,7 @@ type mgr struct {
 
 	// Physical source (updated by source watcher goroutine)
 	physicalSource    string             // "Physical" or "None"
+	lastPhysicalAt    time.Time          // last time physicalSource was "Physical"
 	recognitionResult *RecognitionResult // last successful recognition; nil until identified
 
 	// recognizeTrigger is sent to when a new recognition attempt should start:
@@ -432,7 +437,11 @@ func (m *mgr) pollSourceFile() {
 
 	m.mu.Lock()
 	changed := m.physicalSource != src
-	if changed && src != "Physical" {
+	if src == "Physical" {
+		m.lastPhysicalAt = time.Now()
+	}
+	if changed && src == "Physical" {
+		// New physical session — clear stale result from a previous session.
 		m.recognitionResult = nil
 	}
 	m.physicalSource = src
@@ -455,6 +464,10 @@ func (m *mgr) pollSourceFile() {
 
 // buildState merges AirPlay and physical source state into the output schema.
 // Source priority: AirPlay (active session) > physical detector (Vinyl/CD) > None.
+//
+// Idle delay: when physical audio stops, the last track is kept visible for
+// IdleDelay seconds before switching to the idle screen. This covers the normal
+// gap between tracks on a record without blanking the display.
 func (m *mgr) buildState() PlayerState {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -462,13 +475,18 @@ func (m *mgr) buildState() PlayerState {
 	source := "None"
 	state := "stopped"
 
+	// physicalActive is true either when audio is currently detected, or when
+	// it stopped recently enough to still be within the idle delay window.
+	physicalActive := m.physicalSource == "Physical" ||
+		(!m.lastPhysicalAt.IsZero() && time.Since(m.lastPhysicalAt) < m.cfg.IdleDelay)
+
 	switch {
 	case m.airplayPlaying:
 		// Streaming source takes priority — physical media detection is ignored
 		// when AirPlay (or future Bluetooth/UPnP) is active.
 		source = "AirPlay"
 		state = "playing"
-	case m.physicalSource == "Physical":
+	case physicalActive:
 		source = "Physical"
 		state = "playing"
 	}
@@ -579,13 +597,7 @@ func (m *mgr) readVUFrames(ctx context.Context, conn net.Conn, silenceThreshold 
 			activeCount = 0
 			if silenceCount >= silenceFrames && !inSilence {
 				inSilence = true
-				// Silence confirmed — clear the recognition result immediately so
-				// the UI shows nothing rather than the previous track.
-				m.mu.Lock()
-				m.recognitionResult = nil
-				m.mu.Unlock()
-				m.markDirty()
-				log.Printf("VU monitor: silence detected — cleared recognition result")
+				log.Printf("VU monitor: silence detected")
 			}
 		} else {
 			activeCount++
@@ -625,7 +637,9 @@ func (m *mgr) runRecognizer(ctx context.Context, rec Recognizer) {
 	var backoffUntil time.Time
 
 	for {
-		// Wait for a trigger or the max interval fallback.
+		// Wait for a trigger (track boundary or new physical session).
+		// The max interval fallback only fires when we have no result yet —
+		// once a track is identified, recognition waits for the next boundary.
 		select {
 		case <-ctx.Done():
 			return
@@ -633,8 +647,9 @@ func (m *mgr) runRecognizer(ctx context.Context, rec Recognizer) {
 		case <-time.After(m.cfg.RecognizerMaxInterval):
 			m.mu.Lock()
 			isPhysical := m.physicalSource == "Physical"
+			hasResult := m.recognitionResult != nil
 			m.mu.Unlock()
-			if !isPhysical {
+			if !isPhysical || hasResult {
 				continue
 			}
 		}
@@ -705,8 +720,24 @@ func (m *mgr) runRecognizer(ctx context.Context, rec Recognizer) {
 }
 
 // runWriter consumes change notifications and atomically writes the state JSON file.
+// It also re-evaluates state on a 5-second tick so that the idle delay expiry is
+// reflected in the output file without waiting for another event.
 // Runs in the main goroutine.
 func (m *mgr) runWriter(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	write := func() {
+		ps := m.buildState()
+		if err := writeStateFile(m.cfg.OutputFile, ps); err != nil {
+			log.Printf("failed to write state: %v", err)
+			return
+		}
+		if m.cfg.Verbose {
+			log.Printf("state written: source=%s state=%s", ps.Source, ps.State)
+		}
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -717,13 +748,16 @@ func (m *mgr) runWriter(ctx context.Context) {
 			})
 			return
 		case <-m.notify:
-			ps := m.buildState()
-			if err := writeStateFile(m.cfg.OutputFile, ps); err != nil {
-				log.Printf("failed to write state: %v", err)
-				continue
-			}
-			if m.cfg.Verbose {
-				log.Printf("state written: source=%s state=%s", ps.Source, ps.State)
+			write()
+		case <-ticker.C:
+			// Re-evaluate periodically so idle delay expiry is written promptly.
+			m.mu.Lock()
+			inIdleWindow := m.physicalSource != "Physical" &&
+				!m.lastPhysicalAt.IsZero() &&
+				time.Since(m.lastPhysicalAt) < m.cfg.IdleDelay
+			m.mu.Unlock()
+			if inIdleWindow {
+				write()
 			}
 		}
 	}
@@ -763,7 +797,8 @@ func main() {
 	flag.StringVar(&cfg.PCMSocket, "pcm-socket", cfg.PCMSocket, "Unix socket for raw PCM from oceano-source-detector")
 	flag.StringVar(&cfg.VUSocket, "vu-socket", cfg.VUSocket, "Unix socket for VU frames from oceano-source-detector")
 	flag.DurationVar(&cfg.RecognizerCaptureDuration, "recognizer-capture-duration", cfg.RecognizerCaptureDuration, "audio capture duration per recognition attempt")
-	flag.DurationVar(&cfg.RecognizerMaxInterval, "recognizer-max-interval", cfg.RecognizerMaxInterval, "fallback re-recognition interval when no track boundary is detected")
+	flag.DurationVar(&cfg.RecognizerMaxInterval, "recognizer-max-interval", cfg.RecognizerMaxInterval, "fallback re-recognition interval when no track boundary is detected and no result is held")
+	flag.DurationVar(&cfg.IdleDelay, "idle-delay", cfg.IdleDelay, "how long to keep showing the last track after audio stops before switching to idle screen")
 	flag.Parse()
 
 	log.Printf("oceano-state-manager starting")


### PR DESCRIPTION
- cmd/oceano-web: new HTTP config UI (port 8080) with device picker, live status bar, and Save & Restart Services
- install.sh: orchestrates all sub-scripts, installs Go and system deps, fixes config.env written before services start
- install-source-detector.sh: add --pcm-socket, fix ExecStart generation
- install-source-manager.sh: fix ExecStart for missing ACRCloud creds, add --idle-delay flag
- state manager: idle delay (60s) keeps last track visible after audio stops; recognition only re-runs after silence gap, not on a blind timer; VU monitor no longer clears result on silence
- README: first-time setup section, troubleshooting expanded, web UI docs
- CLAUDE.md: documentation hygiene rule added