### PR TITLE
refactor web command execution behind adapters

### DIFF
--- a/cmd/oceano-web/command_adapters.go
+++ b/cmd/oceano-web/command_adapters.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type CommandRunner interface {
+	Run(name string, args ...string) error
+	OutputContext(ctx context.Context, name string, args ...string) ([]byte, error)
+	CombinedOutput(name string, args ...string) ([]byte, error)
+	CombinedOutputContext(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type OSCommandRunner struct{}
+
+func (OSCommandRunner) Run(name string, args ...string) error {
+	return exec.Command(name, args...).Run()
+}
+
+func (OSCommandRunner) OutputContext(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).Output()
+}
+
+func (OSCommandRunner) CombinedOutput(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput()
+}
+
+func (OSCommandRunner) CombinedOutputContext(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+type ServiceManager interface {
+	Restart(unit string) error
+	PowerAction(action string)
+	SignalMain(unit string, signal string) error
+}
+
+type SystemdServiceManager struct {
+	runner CommandRunner
+	sleep  func(time.Duration)
+}
+
+func NewSystemdServiceManager(runner CommandRunner) *SystemdServiceManager {
+	return &SystemdServiceManager{
+		runner: runner,
+		sleep:  time.Sleep,
+	}
+}
+
+func (m *SystemdServiceManager) Restart(unit string) error {
+	if err := m.runner.Run("systemctl", "daemon-reload"); err != nil {
+		return fmt.Errorf("daemon-reload: %w", err)
+	}
+	out, err := m.runner.CombinedOutput("systemctl", "restart", unit)
+	if err != nil {
+		return fmt.Errorf("%s: %s", unit, strings.TrimSpace(string(out)))
+	}
+	m.sleep(500 * time.Millisecond)
+	return nil
+}
+
+func (m *SystemdServiceManager) PowerAction(action string) {
+	_ = m.runner.Run("systemctl", action)
+}
+
+func (m *SystemdServiceManager) SignalMain(unit string, signal string) error {
+	return m.runner.Run("systemctl", "kill", "--kill-who=main", "--signal="+signal, unit)
+}
+
+var (
+	commandRunner CommandRunner = OSCommandRunner{}
+	serviceMgr    ServiceManager = NewSystemdServiceManager(commandRunner)
+)

--- a/cmd/oceano-web/handlers_core.go
+++ b/cmd/oceano-web/handlers_core.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -131,7 +130,7 @@ func handlePower() http.HandlerFunc {
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
-		go exec.Command("systemctl", args...).Run()
+		go serviceMgr.PowerAction(args[0])
 	}
 }
 
@@ -141,7 +140,7 @@ func handleRecognize() http.HandlerFunc {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		if err := exec.Command("systemctl", "kill", "--kill-who=main", "--signal=SIGUSR1", managerUnit).Run(); err != nil {
+		if err := serviceMgr.SignalMain(managerUnit, "SIGUSR1"); err != nil {
 			http.Error(w, "failed to signal state manager", http.StatusInternalServerError)
 			return
 		}
@@ -213,7 +212,7 @@ func formatSSEDataFrame(data []byte) string {
 func apiGetBluetoothDevices(w http.ResponseWriter) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "bluetoothctl", "devices", "Paired").Output()
+	out, err := commandRunner.OutputContext(ctx, "bluetoothctl", "devices", "Paired")
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode([]BluetoothDevice{})
@@ -250,8 +249,7 @@ func apiRemoveBluetoothDevice(w http.ResponseWriter, mac string) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "bluetoothctl", "remove", mac)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := commandRunner.CombinedOutputContext(ctx, "bluetoothctl", "remove", mac); err != nil {
 		http.Error(w, strings.TrimSpace(string(out)), http.StatusInternalServerError)
 		return
 	}

--- a/cmd/oceano-web/main.go
+++ b/cmd/oceano-web/main.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -343,15 +342,15 @@ func applyBluetoothConfig(cfg BluetoothConfig) error {
 			return fmt.Errorf("rename %s: %w", confPath, err)
 		}
 		// Restart bluetoothd to pick up the new name from main.conf.
-		_ = exec.Command("systemctl", "restart", "bluetooth.service").Run()
+		_ = commandRunner.Run("systemctl", "restart", "bluetooth.service")
 		// Wait for bluetoothd D-Bus service to be ready before setting the alias.
 		time.Sleep(2 * time.Second)
 	}
 
 	if cfg.Enabled {
-		_ = exec.Command("bluetoothctl", "power", "on").Run()
-		_ = exec.Command("bluetoothctl", "discoverable", "on").Run()
-		_ = exec.Command("bluetoothctl", "pairable", "on").Run()
+		_ = commandRunner.Run("bluetoothctl", "power", "on")
+		_ = commandRunner.Run("bluetoothctl", "discoverable", "on")
+		_ = commandRunner.Run("bluetoothctl", "pairable", "on")
 	}
 
 	// Set adapter alias immediately via dbus-send and update the persistent
@@ -367,10 +366,10 @@ func applyBluetoothConfig(cfg BluetoothConfig) error {
 
 		// Apply immediately to the running adapter. exec.Command args are not
 		// shell-parsed, so spaces in safeName are safe here.
-		_ = exec.Command("dbus-send", "--system", "--print-reply", "--dest=org.bluez",
+		_ = commandRunner.Run("dbus-send", "--system", "--print-reply", "--dest=org.bluez",
 			"/org/bluez/hci0", "org.freedesktop.DBus.Properties.Set",
 			"string:org.bluez.Adapter1", "string:Alias",
-			"variant:string:"+safeName).Run()
+			"variant:string:"+safeName)
 
 		// Build a quoted ExecStart argument so systemd does not split on spaces.
 		// Escape backslashes and double quotes within the name first.
@@ -387,8 +386,8 @@ func applyBluetoothConfig(cfg BluetoothConfig) error {
 			"string:org.bluez.Adapter1 string:Alias " + execArg + "\n" +
 			"RemainAfterExit=no\n\n[Install]\nWantedBy=multi-user.target\n"
 		_ = os.WriteFile("/etc/systemd/system/oceano-bt-alias.service", []byte(unit), 0o644)
-		_ = exec.Command("systemctl", "daemon-reload").Run()
-		_ = exec.Command("systemctl", "restart", "oceano-bt-alias.service").Run()
+		_ = commandRunner.Run("systemctl", "daemon-reload")
+		_ = commandRunner.Run("systemctl", "restart", "oceano-bt-alias.service")
 	}
 
 	return nil
@@ -434,15 +433,6 @@ WantedBy=multi-user.target
 }
 
 func restartService(unit string) error {
-	if err := exec.Command("systemctl", "daemon-reload").Run(); err != nil {
-		return fmt.Errorf("daemon-reload: %w", err)
-	}
-	cmd := exec.Command("systemctl", "restart", unit)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("%s: %s", unit, strings.TrimSpace(string(out)))
-	}
-	// Give the service a moment to start before responding.
-	time.Sleep(500 * time.Millisecond)
-	return nil
+	return serviceMgr.Restart(unit)
 }
 


### PR DESCRIPTION
## Summary
- add `CommandRunner` and `ServiceManager` abstractions in `cmd/oceano-web/command_adapters.go`
- route `systemctl`, `bluetoothctl`, and `dbus-send` call sites in web handlers/config flows through adapters
- keep runtime behavior unchanged while reducing direct process execution coupling in handlers and service restart paths

## Test plan
- [x] `go test ./cmd/oceano-web`
- [x] `go test ./...`
- [x] pre-commit hook suite passes

Made with [Cursor](https://cursor.com)